### PR TITLE
Fallback to original declare_namespace, if __path__ not available in …

### DIFF
--- a/src/horse_with_no_namespace/__init__.py
+++ b/src/horse_with_no_namespace/__init__.py
@@ -42,10 +42,16 @@ def apply():
         # to update __path__ using pkgutil.extend_path instead
         def declare_namespace(packageName):
             parent_locals = sys._getframe(1).f_locals
+
+            if "__path__" not in parent_locals:
+                # Fallback to what pkg_resources does
+                return orig_declare_namespace(packageName)
+
             parent_locals["__path__"] = pkgutil.extend_path(
                 parent_locals["__path__"], packageName
             )
 
+        orig_declare_namespace = pkg_resources.declare_namespace
         pkg_resources.declare_namespace = declare_namespace
 
     # Remove existing namespace package modules that were already created

--- a/src/horse_with_no_namespace/__init__.py
+++ b/src/horse_with_no_namespace/__init__.py
@@ -42,16 +42,10 @@ def apply():
         # to update __path__ using pkgutil.extend_path instead
         def declare_namespace(packageName):
             parent_locals = sys._getframe(1).f_locals
-
-            if "__path__" not in parent_locals:
-                # Fallback to what pkg_resources does
-                return orig_declare_namespace(packageName)
-
             parent_locals["__path__"] = pkgutil.extend_path(
-                parent_locals["__path__"], packageName
+                parent_locals.get("__path__", ""), packageName
             )
 
-        orig_declare_namespace = pkg_resources.declare_namespace
         pkg_resources.declare_namespace = declare_namespace
 
     # Remove existing namespace package modules that were already created


### PR DESCRIPTION
…parent locals.

First, thanks for this package and sharing insight into this haunting problem! It's almost every buildout I touch since a few weeks that breaks.

Here is a clumsy fix for a problem I encountered with an quite old Plone 5.2 based project.

I got this, while running buildout:

```
While:
  Installing instance.
  Getting distribution for 'plone.formwidget.recaptcha==2.3.0'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 2252, in main
    getattr(buildout, command)(args)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 856, in install
    installed_files = self[part]._call(recipe.install)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 1652, in _call
    return f()
  File "/home/thet/.buildout/eggs/cp38/plone.recipe.zope2instance-6.13.0-py3.8.egg/plone/recipe/zope2instance/recipe.py", line 148, in install
    self.build_zope_conf()
  File "/home/thet/.buildout/eggs/cp38/plone.recipe.zope2instance-6.13.0-py3.8.egg/plone/recipe/zope2instance/recipe.py", line 707, in build_zope_conf
    requirements, ws = self.egg.working_set(["plone.recipe.zope2instance"])
  File "/home/thet/.buildout/eggs/cp38/zc.recipe.egg-2.0.7-py3.8-linux-x86_64.egg/zc/recipe/egg/egg.py", line 78, in working_set
    ws = self._working_set(
  File "/home/thet/.buildout/eggs/cp38/zc.recipe.egg-2.0.7-py3.8-linux-x86_64.egg/zc/recipe/egg/egg.py", line 161, in _working_set
    ws = zc.buildout.easy_install.install(
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 971, in install
    return installer.install(specs, working_set)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 744, in install
    for dist in self._get_dist(req, ws):
  File "/home/thet/.buildout/eggs/cp38/plone.versioncheck-1.8.1-py3.8.egg/plone/versioncheck/tracking.py", line 24, in get_dist
    dists = old_get_dist(self, requirement, *ags, **kw)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 581, in _get_dist
    dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 1948, in _move_to_eggs_dir_and_compile
    assert newdist is not None  # newloc above is missing our dist?!
AssertionError
```

the same happened for plone.restapi 7.9.0 and plone.app.robotframework 1.5.6

Then I remembered that I got told about horse-with-no-namespace!

I installed it:

```
thet@thes:/home/_thet/data/dev/my/buildout$ pip install horse-with-no-namespace
Collecting horse-with-no-namespace
  Downloading horse_with_no_namespace-20250408.0-py3-none-any.whl (4.9 kB)
Installing collected packages: horse-with-no-namespace
Successfully installed horse-with-no-namespace-20250408.0
```

re-ran buildout, and:

```
warning: no previously-included files found matching '*.png'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files found matching '*.sh'
warning: no previously-included files found matching '.*.cfg'
warning: no previously-included files found matching '.coveragerc'
warning: no previously-included files found matching '.DS_Store'
warning: no previously-included files found matching '.tx'
warning: no previously-included files found matching '.tx/config'
warning: no previously-included files found matching 'buildout.cfg'
While:
  Installing.
  Getting section _mr.developer.
  Initializing section _mr.developer.
  Installing recipe zc.recipe.egg.
  Getting distribution for 'zc.recipe.egg==2.0.7'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 2252, in main
    getattr(buildout, command)(args)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 740, in install
    [self[part]['recipe'] for part in install_parts]
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 740, in <listcomp>
    [self[part]['recipe'] for part in install_parts]
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 1373, in __getitem__
    options._initialize()
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 1481, in _initialize
    self.initialize()
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 1487, in initialize
    recipe_class = _install_and_load(reqs, 'zc.buildout', entry, buildout)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/buildout.py", line 1430, in _install_and_load
    zc.buildout.easy_install.install(
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 971, in install
    return installer.install(specs, working_set)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 696, in install
    for dist in self._get_dist(requirement, ws):
  File "/home/thet/.buildout/eggs/cp38/plone.versioncheck-1.8.1-py3.8.egg/plone/versioncheck/tracking.py", line 24, in get_dist
    dists = old_get_dist(self, requirement, *ags, **kw)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/zc/buildout/easy_install.py", line 598, in _get_dist
    ws.add(dist)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 721, in add
    self._added_new(dist)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 932, in _added_new
    callback(dist)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3290, in <lambda>
    lambda dist: dist.activate(replace=True),
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2804, in activate
    declare_namespace(pkg)
  File "/home/_thet/data/dev/my/buildout/venv/lib/python3.8/site-packages/horse_with_no_namespace/__init__.py", line 46, in declare_namespace
    parent_locals["__path__"], packageName
KeyError: '__path__'
```

It was zc.recipe.egg and it failed at `packageName` was `zc` in the line where it failed.

This PR should fix that - I thought falling back to the original `declare_namespace` implementation might be just fine.

However, this fix did not solve my original problem. I ended up doing source checkouts for `plone.formwidget.recaptcha` and `plone.restapi`.