### PR TITLE
Handle missing pkg_resources gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - 2025-11-05:
+  Make the `pkg_resources.declare_namespace` patch work even if there's no longer a real `pkg_resources` module.
+- 2025-11-05:
   Fix handling of namespaces that have an `__init__.py` installed.
   Now we read the namespaces from `*.dist-info/namespace_packages.txt` instead of looking for modules that were loaded with NamespaceLoader.
   Also added logging of which namespaces were processed.

--- a/src/horse_with_no_namespace/__about__.py
+++ b/src/horse_with_no_namespace/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025 David Glick <david@glicksoftware.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "20251105.0"
+__version__ = "20251105.1"


### PR DESCRIPTION
Make sure we can still handle editable packages with pkg_resources namespaces after pkg_resources is removed from setuptools (https://github.com/pypa/setuptools/pull/5007)